### PR TITLE
ENH/TEST: Permit interleaving calls to Balancer

### DIFF
--- a/mvpa2/tests/test_generators.py
+++ b/mvpa2/tests/test_generators.py
@@ -259,9 +259,23 @@ def test_balancer():
     assert_false(all(balanced[0].sa.ids == balanced[2].sa.ids))
     assert_false(all(balanced[1].sa.ids == balanced[2].sa.ids))
 
-    # And should be exactly the same
-    assert_true(assert_datasets_equal(ds_a, ds_b)
-                for ds_a, ds_b in zip(balanced, b.generate(ds)))
+    # And interleaving __call__ and generator fetches
+    gen1 = b.generate(ds)
+    gen2 = b.generate(ds)
+
+    seq1, seq2, seq3 = [], [], []
+    for i in xrange(3):
+        seq1.append(gen1.next())
+        seq2.append(gen2.next())
+        seq3.append(b(ds))
+
+    # Produces expected sequences
+    for i in xrange(3):
+        assert_datasets_equal(balanced[i], seq1[i])
+        assert_datasets_equal(balanced[i], seq2[i])
+    # And all __call__s return the same result
+    ds_a = seq3[0]
+    assert_false(any(np.any(ds_a.sa.ids != ds_b.sa.ids) for ds_b in seq3[1:]))
 
     # with limit
     bal = Balancer(limit={'chunks': 3}, apply_selection=True)


### PR DESCRIPTION
There's a race condition here, which is that interleaving generators could produce unexpected datasets.

``` Python
b = Balancer(apply_selection=True, count=5, rng=1)
datasets = list(b.generate(ds))
gen1 = b.generate(ds)
gen2 = b.generate(ds)

seq1 = []
seq2 = []
seq3 = []
for i in xrange(5):
    seq1.append(gen1.next())
    seq2.append(gen2.next())
    seq3.append(b(ds))

# datasets != seq1 != seq2 != datasets
# seq3[0] != seq3[1]
```

This may not actually happen in normal behavior, so this might be a little silly, but it's also silly to get bitten by these things.

The locking is to be thread-safe (RLock can be acquired multiple times by the same thread), though I think that's also not a likely problem in practice.

And the test I replaced was always passing because `assert_true(assert_true False for _ in xrange(5))` passes. (Iterator evaluates to true without running evaluating its contents.)
